### PR TITLE
perf: use stream for `getDeclDeps`

### DIFF
--- a/graph/decl_deps_bench.ts
+++ b/graph/decl_deps_bench.ts
@@ -1,0 +1,69 @@
+import { ReferencedSymbol, ReferencedSymbolEntry } from "../deps/ts_morph.ts"
+import { exampleSrc } from "./_example_project.ts"
+import { inMemoryProject, withSrc } from "./_project.ts"
+import {
+	type Declaration,
+	type DeclDeps,
+	equals,
+	getDeclDeps,
+	getTopDecl,
+} from "./decl_deps.ts"
+import { Stream } from "https://deno.land/x/rimbu@1.2.0/stream/mod.ts"
+import { getAllDecls } from "./decls.ts"
+
+/**
+ * Find all references in other files
+ *
+ * TODO: use isDefinition()?
+ */
+const getActualReferencesArray = (
+	symbol: ReferencedSymbol,
+): ReferencedSymbolEntry[] =>
+	symbol
+		.getReferences()
+		.filter((ref) => !equals(ref.getNode(), symbol.getDefinition().getNode()))
+		.filter((ref) =>
+			ref.getNode().getParent()?.getKindName() !== "ImportClause"
+		)
+
+const getReferencedDeclsArray = (node: Declaration): Declaration[] =>
+	node.findReferences()
+		.flatMap(getActualReferencesArray)
+		.flatMap((x) => getTopDecl(x) ?? [])
+
+/**
+ * Recursively query **direct** variable references into key-value map.
+ */
+export const getDeclDepsArray = (links: Declaration[]): DeclDeps => {
+	const graph: DeclDeps = new Map()
+
+	let current = links
+	while (current.length > 0) {
+		current = current.flatMap((node) => {
+			const references = getReferencedDeclsArray(node)
+			graph.set(node, references)
+			return references
+		})
+	}
+	return graph
+}
+
+Deno.bench(`array`, (b) => {
+	const project = inMemoryProject()
+	const files = withSrc(project)(exampleSrc)
+	const decls = Stream.fromObjectValues(files).flatMap(getAllDecls).toArray()
+
+	b.start()
+	const _declDeps = getDeclDepsArray(decls)
+	b.end()
+})
+
+Deno.bench(`stream`, { baseline: true }, (b) => {
+	const project = inMemoryProject()
+	const files = withSrc(project)(exampleSrc)
+	const decls = Stream.fromObjectValues(files).flatMap(getAllDecls).toArray()
+
+	b.start()
+	const _declDeps = getDeclDeps(decls)
+	b.end()
+})


### PR DESCRIPTION
```
runtime: deno 1.41.0 (aarch64-apple-darwin)

file:///Users/nemo/repo/stackgraph/graph/decl_deps_bench.ts
benchmark      time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------- -----------------------------
array           3.55 ms/iter         281.3     (2.2 ms … 10.47 ms) 4.09 ms 6.55 ms 10.47 ms
stream          2.52 ms/iter         397.2     (1.87 ms … 6.01 ms) 2.61 ms 5.62 ms 6.01 ms

summary
  stream
   1.41x faster than array
```

- around ~40% performance improvement
- no noticable differences in IRL performance (~500 files)
- bottleneck seems to come from [`ReferenceFindableNode.findReferences()`](https://ts-morph.com/navigation/finding-references#finding-referencing-nodes)