### PR TITLE
feat!: `getGraph`, rename `graphToTopDeclDeps` to `getTopDeclDeps`

### DIFF
--- a/graph/__snapshots__/top_decl_deps_test.ts.snap
+++ b/graph/__snapshots__/top_decl_deps_test.ts.snap
@@ -1,6 +1,6 @@
 export const snapshot = {};
 
-snapshot[`graphToTopDeclDeps() converts graph into valid TopDeclDeps 1`] = `
+snapshot[`getTopDeclDeps() converts graph into valid TopDeclDeps 1`] = `
 {
   "AliasedImport (/d.tsx:6:22)": [
     "a (/a.ts:2:22)",

--- a/graph/graph.ts
+++ b/graph/graph.ts
@@ -1,7 +1,7 @@
 import type { GraphElement } from "https://deno.land/x/rimbu@1.2.0/graph/custom/common/link.ts"
 import { ArrowGraphHashed } from "https://deno.land/x/rimbu@1.2.0/graph/mod.ts"
 import { Stream } from "https://deno.land/x/rimbu@1.2.0/stream/mod.ts"
-import { DeclDeps } from "./decl_deps.ts"
+import { type Declaration, type DeclDeps, getDeclDeps } from "./decl_deps.ts"
 import { encodeVSCodeURI, type VSCodeURI } from "./vscode_uri.ts"
 
 /** directed graph of references */
@@ -15,3 +15,6 @@ export const declDepsToGraph = (declDeps: DeclDeps): Graph =>
 		])
 	)
 		.reduce(ArrowGraphHashed.reducer())
+
+export const getGraph = (decls: Declaration[]): Graph =>
+	declDepsToGraph(getDeclDeps(decls))

--- a/graph/mod.ts
+++ b/graph/mod.ts
@@ -1,8 +1,8 @@
 // deno-lint-ignore-file no-unused-vars
 import type { getDecls } from "./decls.ts"
 import type { DeclDeps, getDeclDeps } from "./decl_deps.ts"
-import type { declDepsToGraph, Graph } from "./graph.ts"
-import type { graphToTopDeclDeps, TopDeclDeps } from "./top_decl_deps.ts"
+import type { declDepsToGraph, getGraph, Graph } from "./graph.ts"
+import type { getTopDeclDeps, TopDeclDeps } from "./top_decl_deps.ts"
 
 /**
  * @module
@@ -36,10 +36,11 @@ import type { graphToTopDeclDeps, TopDeclDeps } from "./top_decl_deps.ts"
  * ### Getting `graph`
  *
  * generate {@link Graph} using {@link declDepsToGraph}
+ * or use shortcut {@link getGraph}
  *
  * ### Getting `top decl deps`
  *
- * generate {@link TopDeclDeps} using {@link graphToTopDeclDeps}
+ * generate {@link TopDeclDeps} using {@link getTopDeclDeps}
  */
 
 export * from "./decls.ts"

--- a/graph/top_decl_deps.ts
+++ b/graph/top_decl_deps.ts
@@ -22,5 +22,5 @@ export type TopDeclDeps = Map<VSCodeURI, Set<VSCodeURI>>
  * TOP2 <- B, a, c
  * ```
  */
-export const graphToTopDeclDeps = (graph: Graph): TopDeclDeps =>
+export const getTopDeclDeps = (graph: Graph): TopDeclDeps =>
 	graphDescendants(graph)

--- a/graph/top_decl_deps_test.ts
+++ b/graph/top_decl_deps_test.ts
@@ -5,12 +5,12 @@ import { inMemoryProject, withSrc } from "./_project.ts"
 import { getDeclDeps } from "./decl_deps.ts"
 import { getAllDecls } from "./decls.ts"
 import { declDepsToGraph } from "./graph.ts"
-import { graphToTopDeclDeps } from "./top_decl_deps.ts"
+import { getTopDeclDeps } from "./top_decl_deps.ts"
 import { snapshotTest } from "./_snapshot.ts"
 import { topDeclDepsSerializer } from "./_format.ts"
 
 snapshotTest(
-	"graphToTopDeclDeps() converts graph into valid TopDeclDeps",
+	"getTopDeclDeps() converts graph into valid TopDeclDeps",
 	async (t) => {
 		const project = inMemoryProject()
 		const files = withSrc(project)(exampleSrc)
@@ -18,7 +18,7 @@ snapshotTest(
 		const declDeps = getDeclDeps(decls)
 		const graph = declDepsToGraph(declDeps)
 
-		const topDeclDeps = graphToTopDeclDeps(graph)
+		const topDeclDeps = getTopDeclDeps(graph)
 
 		await assertSnapshot(t, topDeclDeps, { serializer: topDeclDepsSerializer })
 	},


### PR DESCRIPTION
1. make user `graph/` api use consistent naming convention `get*`
2. add `getGraph = declDepsToGraph(getDeclDeps(decls))` as there's no real benefits of having intermediate `DeclDeps` for end users