### PR TITLE
ci: cache all files

### DIFF
--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -22,8 +22,8 @@ jobs:
       - name: Clone repository
         uses: actions/checkout@v4
 
-      - name: Cache Deno dependencies
-        uses: actions/cache@v4
+      - name: Load Deno Dependencies
+        uses: actions/cache/restore@v4
         with:
           path: ${{ env.DENO_DIR }}
           key: ${{ hashFiles('deno.lock') }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,8 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Deno dependencies
-        uses: actions/cache/restore@v4
+      - name: Load Deno Dependencies
+        uses: actions/cache@v4
         with:
           path: ${{ env.DENO_DIR }}
           key: ${{ hashFiles('deno.lock') }}
@@ -29,6 +29,8 @@ jobs:
         run: deno lint
       - name: Check formatting
         run: deno fmt --check
+      - name: Cache Deno dependencies
+        run: deno cache ./**/*.ts
 
   test:
     runs-on: ubuntu-latest
@@ -38,7 +40,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache Deno dependencies
+      - name: Load Deno Dependencies
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.DENO_DIR }}


### PR DESCRIPTION
explicitly cache all imports for `deno cache ./**.*.ts` to prevent extraneous module downloads.